### PR TITLE
fileKey() should return null if it's not supported

### DIFF
--- a/truevfs-access/src/main/java/net/java/truevfs/access/TFileSystem.java
+++ b/truevfs-access/src/main/java/net/java/truevfs/access/TFileSystem.java
@@ -502,10 +502,9 @@ public final class TFileSystem extends FileSystem {
             return UNKNOWN == size ? 0 : size;
         }
 
-        /** @throws UnsupportedOperationException always */
         @Override
         public Object fileKey() {
-            throw new UnsupportedOperationException("Not supported yet.");
+            return null;
         }
     } // FsNodeAttributes
 }


### PR DESCRIPTION
Fixes https://github.com/christian-schlichtherle/truevfs/issues/9
Not tested, but should work.